### PR TITLE
require CMake 2.8.12

### DIFF
--- a/README
+++ b/README
@@ -9,7 +9,7 @@ source from Git and driving a fresh build.  Using the scripts
 in this directory, you can quickly set up an automatic build
 and test of libarchive.
 
-Step 0:  Install cmake 2.8.0 or later on your system.
+Step 0:  Install cmake 2.8.12 or later on your system.
   You can use 'ctest --version' to check what version is installed.
 
 Step 1:  Customize libarchive_test.cmake for your system.

--- a/scripts/libarchive_common.cmake
+++ b/scripts/libarchive_common.cmake
@@ -48,7 +48,7 @@
 #   set(ENV{FC}  /path/to/fc)   # Fortran compiler (optional)
 #   set(ENV{LD_LIBRARY_PATH} /path/to/vendor/lib) # (if necessary)
 
-cmake_minimum_required(VERSION 2.8.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 set(CTEST_PROJECT_NAME libarchive)
 


### PR DESCRIPTION
libarchive itself also requires that version.

Otherwise one gets these warnings when running the dashboard script:

```
CMake Deprecation Warning at .../libarchive-cdash/scripts/libarchive_common.cmake:51 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.
```